### PR TITLE
동적쿼리 적용으로 게시글 리스트 조회 메서드 통합 구현

### DIFF
--- a/src/main/java/com/hanghae/mungnayng/config/QuerydslConfig.java
+++ b/src/main/java/com/hanghae/mungnayng/config/QuerydslConfig.java
@@ -14,6 +14,6 @@ public class QuerydslConfig {
 
     @Bean
     public JPAQueryFactory jpaQueryFactory() {      /* JPAQueryFactory를 사용하면 EntityManager를 통해 질의가 처리되고,JPQL을 생성하여 처리 */
-        return new JPAQueryFactory(entityManager);
-    }
-}
+        return new JPAQueryFactory(entityManager);  /* EntityManager는 영속성 컨텍스트에 접근하여 Entity에 대한 DB 작업을 제공하고 관리한다 */
+    }                                               /* 영속성 컨텍스트란 Entity를 영구적으로 저장하는 환경을 뜻한다 */
+}                                                   /* 어플리케이션과 DB사이의 객체를 저장하는 가상의 DB 역할 수행 */

--- a/src/main/java/com/hanghae/mungnayng/controller/ItemController.java
+++ b/src/main/java/com/hanghae/mungnayng/controller/ItemController.java
@@ -42,38 +42,6 @@ public class ItemController {
         return ResponseEntity.ok().body(itemService.getAllItem(itemRequestParam, pageable));
     }
 
-    /* 카테고리에 따른 상품 조회(MainPage/단일 카테고리 - petCategory) */
-//    @ApiOperation(value = "pet_category에 따른 상품 조회 메소드")
-//    @GetMapping("items/petcategory")
-//    public ResponseEntity<?> getItemByPetCategory(@RequestParam("petCategory") String petCategory,
-//                                                  @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
-//        return ResponseEntity.ok().body(itemService.getItemByPetCategory(petCategory, pageable));
-//    }
-
-    /* 카테고리에 따른 상품 조회(MainPage/단일 카테고리 - petCategory) */
-    @ApiOperation(value = "pet_category에 따른 상품 조회 메소드")
-    @GetMapping("items/petcategory")
-    public ResponseEntity<?> getItemByPetCategory(ItemRequestParam itemRequestParam,
-                                                  @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ResponseEntity.ok().body(itemService.getItemByPetCategory(itemRequestParam, pageable));
-    }
-
-    /* 카테고리에 따른 상품 조회(MainPage/단일 카테고리 - itemCategory) */
-    @ApiOperation(value = "item_category에 따른 상품 조회 메소드")
-    @GetMapping("items/itemcategory")
-    public ResponseEntity<?> getItemByItemCategory(@RequestParam("itemCategory") String itemCategory,
-                                                   @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ResponseEntity.ok().body(itemService.getItemByItemCategory(itemCategory, pageable));
-    }
-
-    /* 카테고리에 따른 상품 조회(MainPage/이중 카테고리) */
-    @ApiOperation(value = "카테고리를 2중(pet_category + item_category)으로 반영한 상품 조회 메소드")
-    @GetMapping("items/twocategory")
-    public ResponseEntity<?> getItemByTwoCategory(@RequestParam("petCategory") String petCategory, @RequestParam("itemCategory") String itemCategory,
-                                                  @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ResponseEntity.ok().body(itemService.getItemByTwoCategory(petCategory, itemCategory, pageable));
-    }
-
     /* 단일 상품 조회(DetailPage) */
     @ApiOperation(value = "단일 상품 조회 메소드")
     @GetMapping("items/detail/{itemId}")
@@ -86,12 +54,6 @@ public class ItemController {
                 .maxAge(24 * 60 * 60)   /* 쿠키 만료 기한은 하루 */
                 .build();
         httpServletResponse.addHeader("Set-Cookie", cookie.toString());
-
-//        Cookie cookie = new Cookie("itemId" + itemId, Long.toString(itemId));    /* itemId로 신규 쿠키 생성(cookie name은 중복불가 */
-//        cookie.setPath("/");
-//        cookie.setMaxAge(24 * 60 * 60);   /* 쿠키 만료 기한은 하루 */
-//        httpServletResponse.addCookie(cookie);   /* response로 쿠키를 담아 보냄 */
-
 
         ItemResponseDto itemResponseDto = itemService.getItem(userDetails, itemId);
         itemService.addViewCnt(itemId);

--- a/src/main/java/com/hanghae/mungnayng/controller/ItemController.java
+++ b/src/main/java/com/hanghae/mungnayng/controller/ItemController.java
@@ -2,6 +2,7 @@ package com.hanghae.mungnayng.controller;
 
 
 import com.hanghae.mungnayng.domain.item.dto.ItemRequestDto;
+import com.hanghae.mungnayng.domain.item.dto.ItemRequestParam;
 import com.hanghae.mungnayng.domain.item.dto.ItemResponseDto;
 import com.hanghae.mungnayng.service.ItemService;
 import io.swagger.annotations.Api;
@@ -36,16 +37,25 @@ public class ItemController {
     /* 전체 상품 조회(MainPage) */
     @ApiOperation(value = "전체 상품 조회 메소드")
     @GetMapping("items")
-    public ResponseEntity<?> getAllItem(@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ResponseEntity.ok().body(itemService.getAllItem(pageable));
+    public ResponseEntity<?> getAllItem(ItemRequestParam itemRequestParam,
+                                        @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok().body(itemService.getAllItem(itemRequestParam, pageable));
     }
+
+    /* 카테고리에 따른 상품 조회(MainPage/단일 카테고리 - petCategory) */
+//    @ApiOperation(value = "pet_category에 따른 상품 조회 메소드")
+//    @GetMapping("items/petcategory")
+//    public ResponseEntity<?> getItemByPetCategory(@RequestParam("petCategory") String petCategory,
+//                                                  @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+//        return ResponseEntity.ok().body(itemService.getItemByPetCategory(petCategory, pageable));
+//    }
 
     /* 카테고리에 따른 상품 조회(MainPage/단일 카테고리 - petCategory) */
     @ApiOperation(value = "pet_category에 따른 상품 조회 메소드")
     @GetMapping("items/petcategory")
-    public ResponseEntity<?> getItemByPetCategory(@RequestParam("petCategory") String petCategory,
+    public ResponseEntity<?> getItemByPetCategory(ItemRequestParam itemRequestParam,
                                                   @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ResponseEntity.ok().body(itemService.getItemByPetCategory(petCategory, pageable));
+        return ResponseEntity.ok().body(itemService.getItemByPetCategory(itemRequestParam, pageable));
     }
 
     /* 카테고리에 따른 상품 조회(MainPage/단일 카테고리 - itemCategory) */

--- a/src/main/java/com/hanghae/mungnayng/domain/item/dto/ItemRequestParam.java
+++ b/src/main/java/com/hanghae/mungnayng/domain/item/dto/ItemRequestParam.java
@@ -1,0 +1,14 @@
+package com.hanghae.mungnayng.domain.item.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.lang.Nullable;
+
+@Getter
+@AllArgsConstructor
+public class ItemRequestParam {
+    @Nullable
+    private String petCategory;
+    @Nullable
+    private String itemCategory;
+}

--- a/src/main/java/com/hanghae/mungnayng/repository/ItemQuerydslRepository.java
+++ b/src/main/java/com/hanghae/mungnayng/repository/ItemQuerydslRepository.java
@@ -1,0 +1,68 @@
+package com.hanghae.mungnayng.repository;
+
+import com.hanghae.mungnayng.domain.item.Item;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Wildcard;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.hanghae.mungnayng.domain.item.QItem.item;
+
+@Repository
+@RequiredArgsConstructor
+public class ItemQuerydslRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    /**
+     * 상품 리스트 조회 동적 쿼리 메서드(전체 상품 조회 및 카테고리에 의한 상품 조회 메서드 통합)
+     */
+    public Page<Item> getItemListByCategory(String petCategory, String itemCategory, Pageable pageable) {
+        /* content - 조건에 맞는 itemList 반환 */
+        List<Item> itemList = jpaQueryFactory.selectFrom(item)
+                .where(
+                        petCategoryEq(petCategory),
+                        itemCategoryEq(itemCategory))
+                .orderBy(item.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+        /* totalCount - 조건에 맞는 itemList를 count */
+        long total = jpaQueryFactory.select(Wildcard.count).from(item)
+                .where(
+                        petCategoryEq(petCategory),
+                        itemCategoryEq(itemCategory))
+                .fetchFirst();
+        /* PageImpl -> Page 인터페이스의 구현체, 인자로 1. content 2. pageable 3. totalCount(content 수)를 받음 */
+        return new PageImpl<>(itemList, pageable, total);
+    }
+
+    /**
+     * 상품 조회 시 해당 상품이 마지막 상품인지 조회하는 메서드(무한 스크롤 구현 위함)
+     */
+    public Long getLastData(String petCategory, String itemCategory) {
+        return jpaQueryFactory.select(item.id.min())
+                .from(item)
+                .where(
+                        petCategoryEq(petCategory),
+                        itemCategoryEq(itemCategory))
+                .orderBy(item.id.desc())
+                .fetchFirst();
+    }
+
+    /* BooleanExpression -> where 절에 필요한 조건식 반환
+     * null 반환 시 조건(where)절에서 조건이 무시(제거)되어 안전 / 전부 null이면 전체 값 호출 */
+    private BooleanExpression petCategoryEq(String petCategory) {
+        return petCategory != null ? item.petCategory.eq(petCategory) : null;
+    }
+
+    private BooleanExpression itemCategoryEq(String itemCateogry) {
+        return itemCateogry != null ? item.itemCategory.eq(itemCateogry) : null;
+    }
+}

--- a/src/main/java/com/hanghae/mungnayng/repository/ItemRepository.java
+++ b/src/main/java/com/hanghae/mungnayng/repository/ItemRepository.java
@@ -12,86 +12,119 @@ import java.util.List;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
 
+    /**
+     * 전체 상품 리스트 조회
+     */
     Page<Item> findAll(Pageable pageable);
 
-    /** 상품 리스트 호출 시 LastData(마지막 게시글)인지 확인 */
-    /* TODO :: queryDSL 사용하여 동적 query 작성 */
+    /**
+     * 상품 리스트 호출 시 LastData(마지막 게시글)인지 확인
+     */
     @Query("select min(i.id) from Item i")   /* 전체 상품 조회 */
     int lastData();
+
     @Query("select min(i.id) from Item i where i.petCategory = :petCategory")    /* 펫 카테고리 */
     int lastDataPetCategory(String petCategory);
+
     @Query("select min(i.id) from Item i where i.itemCategory = :itemCategory")    /* 아이템 카테고리 */
     int lastDataItemCategory(String itemCategory);
+
     @Query("select min(i.id) from Item i where i.petCategory = :petCategory and i.itemCategory = :itemCategory")
     int lastDataTwoCategory(String petCategory, String itemCategory);   /* 이중 카테고리 */
 
-    /** 상품 단일 조회 시 viewCnt + 1 */
+    /**
+     * 상품 단일 조회 시 viewCnt + 1
+     */
     @Modifying
     @Query("update Item i set i.viewCnt = i.viewCnt + 1 where i.id = :id")
     int addViewCnt(Long id);
 
-    /** 이중 카테고리에 의한 조회 */
+    /**
+     * 이중 카테고리에 의한 조회
+     */
     @Query("select i from Item i " +
             "where i.petCategory = :petCategory and i.itemCategory = :itemCategory ")
     Page<Item> getAllItemListByTwoCategory(String petCategory, String itemCategory, Pageable pageable);
 
-    /** 단일 카테고리에 의한 조회 - petCategory */
+    /**
+     * 단일 카테고리에 의한 조회 - petCategory
+     */
     /* TODO :: queryDSL 사용하여 동적 쿼리로 작성(itemCategory로 조회하는 메소드와 합칠 것) */
     @Query("select i from Item i " +
             "where i.petCategory = :petCategory ")
     Page<Item> getAllItemListByPetCategry(String petCategory, Pageable pageable);
 
-    /** 단일 카테고리에 의한 조회 - itemCategory */
+    /**
+     * 단일 카테고리에 의한 조회 - itemCategory
+     */
     @Query("select i from Item i " +
             "where i.itemCategory = :itemCategory ")
     Page<Item> getAllItemListByItemCategory(String itemCategory, Pageable pageable);
 
-    /** 상품 기본 검색 - 최신순 정렬 */
+    /**
+     * 상품 기본 검색 - 최신순 정렬
+     */
     @Query("select i from Item i " +
             "where i.title like %:keyword% or i.content like %:keyword% or " +
             "i.itemCategory like %:keyword% or i.petCategory like %:keyword% " +
             "order by i.createdAt desc ")
     List<Item> getAllItemListByTitleOrContent(String keyword);
 
-    /** 상품 기본 검색 - 인기순 정렬 */
+    /**
+     * 상품 기본 검색 - 인기순 정렬
+     */
     @Query("select i from Item i " +
             "where i.title like %:keyword% or i.content like %:keyword% or " +
             "i.itemCategory like %:keyword% or i.petCategory like %:keyword% " +
             "order by i.viewCnt desc ")
     List<Item> getAllItemListByOrderByPopularity(String keyword);
 
-    /** 내가 찜한 상품 조회 */
+    /**
+     * 내가 찜한 상품 조회
+     */
     @Query("select i from Item i " +
             "inner join Zzim z on i.id = z.item.id " +
             "where z.zzimedBy = :nickname order by z.id desc")
     List<Item> getAllItemListByZzimedId(String nickname);
 
-    /** 내가 등록한 상품 조회 */
+    /**
+     * 내가 등록한 상품 조회
+     */
     @Query("select i from Item i " +
             "where i.nickname = :nickname order by i.createdAt desc ")
     List<Item> getAllItemByNickname(String nickname);
 
-    /** 마이페이지 - 차트용 데이터 호출(자기 등록 상품 가격의 총합) */
+    /**
+     * 마이페이지 - 차트용 데이터 호출(자기 등록 상품 가격의 총합)
+     */
     @Query("select sum(i.sellingPrice) from Item i " +
             "where i.nickname = :nickname group by i.nickname")
     int getFirstItemsPriceSum(String nickname);
 
-    /** 내가 등록한 상품 중 판매 완료 상품 조회 */
+    /**
+     * 내가 등록한 상품 중 판매 완료 상품 조회
+     */
     @Query("select i from Item i " +
             "where i.nickname = :nickname and i.isComplete = true")
     List<Item> getAllSoldItemByNickname(String nickname);
 
-    /** 마이페이지 - 차트용 데이터 호출(판매 완료된 자기 등록 상품 가격의 총합) */
+    /**
+     * 마이페이지 - 차트용 데이터 호출(판매 완료된 자기 등록 상품 가격의 총합)
+     */
     @Query("select sum(i.sellingPrice) from Item i " +
             "where i.isComplete = true and i.nickname = :nickname group by i.nickname")
     int getSecondItemsPriceSum(String nickname);
 
-    /** 마이페이지 - 차트용 데이터 호출(내가 찜한 상품 가격의 총합) */
+    /**
+     * 마이페이지 - 차트용 데이터 호출(내가 찜한 상품 가격의 총합)
+     */
     @Query("select sum(i.sellingPrice) from Item i " +
             "inner join Zzim z on z.item.id = i.id " +
             "where z.zzimedBy = :nickname")
     int getThirdItemsPriceSum(String nickname);
 
-    /** 특정 itemCategory 등록상품 100개 리스트화 메소드(평균 가격 도출 위함) */
+    /**
+     * 특정 itemCategory 등록상품 100개 리스트화 메소드(평균 가격 도출 위함)
+     */
     List<Item> getTop100ByItemCategoryOrderByIdDesc(@Param("itemCategory") String itemCategory);
 }

--- a/src/main/java/com/hanghae/mungnayng/repository/ItemRepository.java
+++ b/src/main/java/com/hanghae/mungnayng/repository/ItemRepository.java
@@ -18,48 +18,11 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     Page<Item> findAll(Pageable pageable);
 
     /**
-     * 상품 리스트 호출 시 LastData(마지막 게시글)인지 확인
-     */
-    @Query("select min(i.id) from Item i")   /* 전체 상품 조회 */
-    int lastData();
-
-    @Query("select min(i.id) from Item i where i.petCategory = :petCategory")    /* 펫 카테고리 */
-    int lastDataPetCategory(String petCategory);
-
-    @Query("select min(i.id) from Item i where i.itemCategory = :itemCategory")    /* 아이템 카테고리 */
-    int lastDataItemCategory(String itemCategory);
-
-    @Query("select min(i.id) from Item i where i.petCategory = :petCategory and i.itemCategory = :itemCategory")
-    int lastDataTwoCategory(String petCategory, String itemCategory);   /* 이중 카테고리 */
-
-    /**
      * 상품 단일 조회 시 viewCnt + 1
      */
     @Modifying
     @Query("update Item i set i.viewCnt = i.viewCnt + 1 where i.id = :id")
-    int addViewCnt(Long id);
-
-    /**
-     * 이중 카테고리에 의한 조회
-     */
-    @Query("select i from Item i " +
-            "where i.petCategory = :petCategory and i.itemCategory = :itemCategory ")
-    Page<Item> getAllItemListByTwoCategory(String petCategory, String itemCategory, Pageable pageable);
-
-    /**
-     * 단일 카테고리에 의한 조회 - petCategory
-     */
-    /* TODO :: queryDSL 사용하여 동적 쿼리로 작성(itemCategory로 조회하는 메소드와 합칠 것) */
-    @Query("select i from Item i " +
-            "where i.petCategory = :petCategory ")
-    Page<Item> getAllItemListByPetCategry(String petCategory, Pageable pageable);
-
-    /**
-     * 단일 카테고리에 의한 조회 - itemCategory
-     */
-    @Query("select i from Item i " +
-            "where i.itemCategory = :itemCategory ")
-    Page<Item> getAllItemListByItemCategory(String itemCategory, Pageable pageable);
+    void addViewCnt(Long id);
 
     /**
      * 상품 기본 검색 - 최신순 정렬

--- a/src/main/java/com/hanghae/mungnayng/service/ItemService.java
+++ b/src/main/java/com/hanghae/mungnayng/service/ItemService.java
@@ -73,81 +73,17 @@ public class ItemService {
      */
     @Transactional(readOnly = true)
     public List<ItemMainResponseDto> getAllItem(ItemRequestParam itemRequestParam, Pageable pageable) {
-//        Page<Item> itemList = itemRepository.findAll(pageable);
+
         Page<Item> itemList = itemQuerydslRepository.getItemListByCategory(
                 itemRequestParam.getPetCategory(), itemRequestParam.getItemCategory(), pageable);
         List<ItemMainResponseDto> itemMainResponseDtoList = new ArrayList<>();
 
-//        int lastData = itemRepository.lastData();   /* FE 무한스크롤 위한 마지막 게시글 확인 */
-        Long lastData = itemQuerydslRepository.getLastData(itemRequestParam.getPetCategory(), itemRequestParam.getItemCategory());  /* FE 무한스크롤 위한 마지막 게시글 확인 */
+        /* FE 무한스크롤 위한 마지막 게시글 확인 */
+        Long lastData = itemQuerydslRepository.getLastData(itemRequestParam.getPetCategory(), itemRequestParam.getItemCategory());
 
         for (Item item : itemList) {
             itemMainResponseDtoList.add(
-                    buildItemMainResponseDto(lastData.intValue(), item)
-            );
-        }
-        return itemMainResponseDtoList;
-    }
-
-    /**
-     * 카테고리에 따른 상품 조회 메서드(MainPage/이중 카테고리)
-     */
-    @Transactional(readOnly = true)
-    public List<ItemMainResponseDto> getItemByTwoCategory(String petCategory, String itemCategory, Pageable pageable) {
-        validator.validateItemCategory(itemCategory);    /* 상품 카테고리 유효성 검사 */
-        validator.validatePetCategory(petCategory);    /* 펫 카테고리 유효성 검사 */
-
-        Page<Item> itemList = itemQuerydslRepository.getItemListByCategory(petCategory, itemCategory, pageable);
-        List<ItemMainResponseDto> itemMainResponseDtoList = new ArrayList<>();
-
-        int lastData = itemRepository.lastDataTwoCategory(petCategory, itemCategory);   /* FE 무한스크롤 위한 마지막 게시글 확인 */
-
-        for (Item item : itemList) {
-            itemMainResponseDtoList.add(
-                    buildItemMainResponseDto(lastData, item)
-            );
-        }
-        return itemMainResponseDtoList;
-    }
-
-    /**
-     * 카테고리에 따른 상품 조회 메서드(MainPage/단일 카테고리 - petCategory)
-     */
-    public List<ItemMainResponseDto> getItemByPetCategory(ItemRequestParam itemRequestParam, Pageable pageable) {
-//        validator.validatePetCategory(itemRequestParam.getPetCategory());    /* 펫 카테고리 유효성 검사 */
-
-        Page<Item> itemList = itemQuerydslRepository.getItemListByCategory(itemRequestParam.getPetCategory(), itemRequestParam.getItemCategory(), pageable);
-//        Page<Item> itemList = itemRepository.getAllItemListByPetCategry(petCategory, pageable);
-        List<ItemMainResponseDto> itemMainResponseDtoList = new ArrayList<>();
-        int lastData = 0;
-        if (itemRequestParam.getPetCategory() != null) {
-            lastData = itemRepository.lastDataPetCategory(itemRequestParam.getPetCategory()); /* FE 무한스크롤 위한 마지막 게시글 확인 */
-        }
-        if (itemRequestParam.getPetCategory() == null && itemRequestParam.getItemCategory() == null) {
-            lastData = itemRepository.lastData();   /* FE 무한스크롤 위한 마지막 게시글 확인 */
-        }
-        for (Item item : itemList) {
-            itemMainResponseDtoList.add(
-                    buildItemMainResponseDto(lastData, item)
-            );
-        }
-        return itemMainResponseDtoList;
-    }
-
-    /**
-     * 카테고리에 따른 상품 조회 메서드(MainPage/단일 카테고리 - itemCategory)
-     */
-    public List<ItemMainResponseDto> getItemByItemCategory(String itemCategory, Pageable pageable) {
-        validator.validateItemCategory(itemCategory);    /* 상품 카테고리 유효성 검사 */
-
-        Page<Item> itemList = itemQuerydslRepository.getItemListByCategory(null, itemCategory, pageable);
-        List<ItemMainResponseDto> itemMainResponseDtoList = new ArrayList<>();
-
-        int lastData = itemRepository.lastDataItemCategory(itemCategory); /* FE 무한스크롤 위한 마지막 게시글 확인 */
-
-        for (Item item : itemList) {
-            itemMainResponseDtoList.add(
-                    buildItemMainResponseDto(lastData, item)
+                    buildISimpleItemResponseDto(lastData.intValue(), item)
             );
         }
         return itemMainResponseDtoList;
@@ -171,7 +107,9 @@ public class ItemService {
         itemRepository.addViewCnt(itemId);
     }
 
-    /* 상품 수정 메서드(detail) */
+    /**
+     * 상품 수정 메서드(detail)
+     */
     @Transactional
     public ItemResponseDto updateItem(UserDetails userDetails, Long itemId, ItemRequestDto itemRequestDto) throws IOException {
         validator.validateUserDetailsInput(userDetails);   /* 로그인 유효성 검사 */
@@ -196,7 +134,9 @@ public class ItemService {
         return buildItemResponseDto(userDetails, item);
     }
 
-    /* 상품 삭제 메서드(detail) */
+    /**
+     * 상품 삭제 메서드(detail)
+     */
     @Transactional
     public void deleteItem(UserDetails userDetails, Long itemId) {
         validator.validateUserDetailsInput(userDetails);   /* 로그인 유효성 검사 */
@@ -206,7 +146,9 @@ public class ItemService {
         itemRepository.delete(item);
     }
 
-    /* 내가 등록한 상품 조회 메서드(mypage) */
+    /**
+     * 내가 등록한 상품 조회 메서드(mypage)
+     */
     @Transactional(readOnly = true)
     public List<ItemResponseDto> getMyItem(UserDetails userDetails) {
         validator.validateUserDetailsInput(userDetails);   /* 로그인 유효성 검사 */
@@ -222,7 +164,9 @@ public class ItemService {
         return itemResponseDtoList;
     }
 
-    /* 마이페이지 - 차트 호출 메서드(mypage) */
+    /**
+     * 마이페이지 - 차트 호출 메서드(mypage)
+     */
     @Transactional(readOnly = true)
     public List<ChartResponseDto> getMyChart(UserDetails userDetails) {
         validator.validateUserDetailsInput(userDetails);   /* 로그인 유효성 검사 */
@@ -267,7 +211,9 @@ public class ItemService {
         return chartResponseDtoList;
     }
 
-    /* 마이페이지 - 내가 조회한 상품 리스트 호출 메서드(mypage) */
+    /**
+     * 마이페이지 - 내가 조회한 상품 리스트 호출 메서드(mypage)
+     */
     public List<ItemMainResponseDto> getItemList(UserDetails userDetails, Map<String, String> data) {
         validator.validateUserDetailsInput(userDetails);   /* 로그인 유효성 검사 */
 
@@ -287,14 +233,16 @@ public class ItemService {
                         () -> new IllegalArgumentException("최근 조회한 상품이 없습니다.")
                 );
                 itemMainResponseDtoList.add(
-                        buildItemMainResponseDto(lastData, item)
+                        buildISimpleItemResponseDto(lastData, item)
                 );
             }
         }
         return itemMainResponseDtoList;
     }
 
-    /* Detail 페이지용 ResponseDto build */
+    /**
+     * 공통작업 - ItemResponseDto build(상품 상세페이지용)
+     */
     private ItemResponseDto buildItemResponseDto(UserDetails userDetails, Item item) {
 
         int commentCnt = commentRepository.countByItem_Id(item.getId());
@@ -346,12 +294,11 @@ public class ItemService {
                 .build();
     }
 
-    /* 공통작업 - Main 페이지용 ResponseDto build */
-    private ItemMainResponseDto buildItemMainResponseDto(int lastData, Item item) {
-        boolean isLastData = false;
-        if (item.getId() == lastData) {
-            isLastData = true;
-        }
+    /**
+     * 공통작업 - ItemResponseDto build(메인페이지 및 마이페이지에서의 사용 위한 간략정보만을 담음)
+     */
+    private ItemMainResponseDto buildISimpleItemResponseDto(int lastData, Item item) {
+        boolean isLastData = item.getId() == lastData;  /* FE 무한스크롤 위한 마지막 게시글 확인 */
 
         /* 해당 item의 이미지 호출 */
         List<Image> imageList = imageRepository.findAllByItemId(item.getId());

--- a/src/main/java/com/hanghae/mungnayng/service/SearchService.java
+++ b/src/main/java/com/hanghae/mungnayng/service/SearchService.java
@@ -29,7 +29,9 @@ public class SearchService {
     private final MemberRepository memberRepository;
     private final Validator validator;
 
-    /** 상품 기본 검색 메서드 - 최신순 정렬(item.title, content, petCategory, itemCategory) */
+    /**
+     * 상품 기본 검색 메서드 - 최신순 정렬(item.title, content, petCategory, itemCategory)
+     */
     @Transactional
     public List<ItemMainResponseDto> searchItem(UserDetails userDetails, String toggle, String keyword) {
         String nickname = "nonMember";  /* 비회원으로 검색할 경우 nickname은 nonMember로 저장 */
@@ -37,7 +39,7 @@ public class SearchService {
             nickname = (userDetails.getUsername());
         }
 
-        if(toggle.equals("true")) {     /* 검색어 자동저장 토글 on(true)일 경우에만 검색어 저장*/
+        if (toggle.equals("true")) {     /* 검색어 자동저장 토글 on(true)일 경우에만 검색어 저장*/
             ItemSearch itemSearch = ItemSearch.builder()
                     .nickname(nickname)
                     .searchWord(keyword)
@@ -50,14 +52,16 @@ public class SearchService {
         List<ItemMainResponseDto> itemMainResponseDtoList = new ArrayList<>();
         for (Item item : itemList) {
             itemMainResponseDtoList.add(
-                    buildItemMainResponseDto(item)
+                    buildSimpleItemResponseDto(item)
             );
         }
 
         return itemMainResponseDtoList;
     }
 
-    /** 상품 기본 검색 - 인기순 정렬(item.title, content, petCategory, itemCategory) */
+    /**
+     * 상품 기본 검색 - 인기순 정렬(item.title, content, petCategory, itemCategory)
+     */
     @Transactional
     public List<ItemMainResponseDto> searchItemOrderByPopularity(UserDetails userDetails, String toggle, String keyword) {
         String nickname = "nonMember";
@@ -65,7 +69,7 @@ public class SearchService {
             nickname = (userDetails.getUsername());
         }
 
-        if(toggle.equals("true")) {     /* 검색어 자동저장 토글 on(true)일 경우에만 검색어 저장*/
+        if (toggle.equals("true")) {     /* 검색어 자동저장 토글 on(true)일 경우에만 검색어 저장*/
             ItemSearch itemSearch = ItemSearch.builder()
                     .nickname(nickname)
                     .searchWord(keyword)
@@ -78,24 +82,28 @@ public class SearchService {
         List<ItemMainResponseDto> itemMainResponseDtoList = new ArrayList<>();
         for (Item item : itemList) {
             itemMainResponseDtoList.add(
-                    buildItemMainResponseDto(item)
+                    buildSimpleItemResponseDto(item)
             );
         }
 
         return itemMainResponseDtoList;
     }
 
-    /** 검색어 자동저장 토글 상태값 가져오기 메서드 */
+    /**
+     * 검색어 자동저장 토글 상태값 가져오기 메서드
+     */
     @Transactional(readOnly = true)
-    public boolean getToggleStatus(UserDetails userDetails){
+    public boolean getToggleStatus(UserDetails userDetails) {
         validator.validateUserDetailsInput(userDetails);   /* 로그인 유효성 검사 */
 
         Member member = memberRepository.findByNickname(userDetails.getUsername());
         return member.isToggle();
     }
 
-    /* 공통 작업 - ResponseDto build */
-    private ItemMainResponseDto buildItemMainResponseDto(Item item) {
+    /**
+     * 공통작업 - ItemResponseDto build(검색 결과 페이지에서의 사용 위한 간략정보만을 담음)
+     */
+    private ItemMainResponseDto buildSimpleItemResponseDto(Item item) {
 
         // 해당 item의 이미지 호출
         List<Image> imageList = imageRepository.findAllByItemId(item.getId());
@@ -120,7 +128,9 @@ public class SearchService {
                 .build();
     }
 
-    /* 최근 검색어 조회 메서드 */
+    /**
+     * 최근 검색어 조회 메서드
+     */
     public List<ItemSearchResponseDto> getSearchWord(UserDetails userDetails, Pageable pageable) {
         List<ItemSearchResponseDto> itemSearchResponseDtoList = new ArrayList<>();
 
@@ -140,7 +150,9 @@ public class SearchService {
         return itemSearchResponseDtoList;
     }
 
-    /* 최근 검색어 개별 삭제 메서드 */
+    /**
+     * 최근 검색어 개별 삭제 메서드
+     */
     public void deleteSearchWord(UserDetails userDetails, String searchWord) {
         validator.validateUserDetailsInput(userDetails);   /* 로그인 유효성 검사 */
 
@@ -148,7 +160,9 @@ public class SearchService {
         searchRepository.delete(itemSearch);
     }
 
-    /* 최근 검색어 전체 삭제 메서드 */
+    /**
+     * 최근 검색어 전체 삭제 메서드
+     */
     public void deleteAllSearchWord(UserDetails userDetails) {
         validator.validateUserDetailsInput(userDetails);   /* 로그인 유효성 검사 */
 
@@ -156,7 +170,9 @@ public class SearchService {
         searchRepository.deleteAll(itemSearchList);
     }
 
-    /* 인기 검색어 조회 메서드 */
+    /**
+     * 인기 검색어 조회 메서드
+     */
     public List<ItemSearchResponseDto> getPopularSearchWord(Pageable pageable) {
         Page<String> searchwordList = searchRepository.getAllByPopularity(pageable);
         List<ItemSearchResponseDto> itemSearchResponseDtoList = new ArrayList<>();
@@ -170,7 +186,9 @@ public class SearchService {
         return itemSearchResponseDtoList;
     }
 
-    /* 검색어 자동완성 메서드 */
+    /**
+     * 검색어 자동완성 메서드
+     */
     public List<ItemSearchResponseDto> getKeywordAutomatically(String keyword) {
         List<String> searchwordList = searchRepository.getSearchwordByKeyword(keyword);
         List<ItemSearchResponseDto> itemSearchResponseDtoList = new ArrayList<>();

--- a/src/main/java/com/hanghae/mungnayng/service/ZzimService.java
+++ b/src/main/java/com/hanghae/mungnayng/service/ZzimService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -27,7 +28,9 @@ public class ZzimService {
     private final ImageRepository imageRepository;
     private final Validator validator;
 
-    /* 찜 하기 */
+    /**
+     * 찜 하기 메서드
+     */
     @Transactional
     public void itemZzim(Long itemId, UserDetails userDetails) {
         validator.validateUserDetailsInput(userDetails);   /* 로그인 유효성 검사 */
@@ -51,7 +54,9 @@ public class ZzimService {
         item.updateZzimCnt(zzimCnt);
     }
 
-    /* 찜 취소 */
+    /**
+     * 찜 취소 메서드
+     */
     @Transactional
     public void cancelZzim(Long itemId, UserDetails userDetails) {
         validator.validateUserDetailsInput(userDetails);   /* 로그인 유효성 검사 */
@@ -71,7 +76,9 @@ public class ZzimService {
         item.updateZzimCnt(zzimCnt);
     }
 
-    /* 내가 찜한 상품 가져오기 */
+    /**
+     * 내가 찜한 상품 가져오기 메서드(마이페이지용)
+     */
     @Transactional(readOnly = true)
     public List<ItemMainResponseDto> getZzimItem(UserDetails userDetails) {
         validator.validateUserDetailsInput(userDetails);   /* 로그인 유효성 검사 */
@@ -106,7 +113,9 @@ public class ZzimService {
         return itemMainResponseDtoList;
     }
 
-    /* 거래 완료 버튼 */
+    /**
+     * 거래 완료 메서드(상품상세페이지용)
+     */
     @Transactional
     public Boolean purchaseComplete(Long itemId, UserDetails userDetails) {
         validator.validateUserDetailsInput(userDetails);   /* 로그인 유효성 검사 */

--- a/src/main/java/com/hanghae/mungnayng/util/Validator.java
+++ b/src/main/java/com/hanghae/mungnayng/util/Validator.java
@@ -44,20 +44,6 @@ public class Validator {
         }
     }
 
-    /* 공통작업 - 상품 카테고리 유효성 검사 메소드화 */
-    public void validateItemCategory(String itemCategory) {
-        if (itemCategory == null || itemCategory.equals("")) {
-            throw new IllegalArgumentException("상품 카테고리를 선택해주세요.");
-        }
-    }
-
-    /* 공통작업 - 펫 카테고리 유효성 검사 메소드화 */
-    public void validatePetCategory(String petCategory) {
-        if (petCategory == null || petCategory.equals("")) {
-            throw new IllegalArgumentException("펫 카테고리를 선택해주세요.");
-        }
-    }
-
     /* 상품 존재 여부 유효성 검사 및 반환 */
     public Item validateItemExistence(Long itemId) {
         return itemRepository.findById(itemId).orElseThrow(


### PR DESCRIPTION
기존 4개로 구분되어있던 상품 리스트 조회 메서드(전체, itemCategroy, petCategory, 이중카테고리)를 동적쿼리 구현을 통해 하나로 통합하였습니다.
확인 부탁드리겠습니다.